### PR TITLE
Add Nix + AppImage build support

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,0 +1,96 @@
+name: Build AppImage
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (optional)'
+        required: false
+
+jobs:
+  build-appimage:
+    name: Build AppImage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v25
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build AppImage
+        run: |
+          nix build .#appimage --print-build-logs
+
+      - name: Get version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.tag }}"
+            [ -z "$VERSION" ] && VERSION=$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+          else
+            VERSION="dev"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Building version: $VERSION"
+
+      - name: Find and rename AppImage
+        run: |
+          mkdir -p release
+          cp result/*.AppImage release/Scratchmark-${{ steps.version.outputs.version }}-x86_64.AppImage
+          chmod +x release/Scratchmark-${{ steps.version.outputs.version }}-x86_64.AppImage
+          ls -lh release/
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scratchmark-appimage
+          path: release/*.AppImage
+          retention-days: 30
+
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: release/*.AppImage
+          draft: false
+          prerelease: false
+          body: |
+            ## AppImage
+
+            Download the AppImage and make it executable:
+            ```bash
+            chmod +x Scratchmark-${{ steps.version.outputs.version }}-x86_64.AppImage
+            ./Scratchmark-${{ steps.version.outputs.version }}-x86_64.AppImage
+            ```
+
+            **System Requirements:**
+            - gtk4
+            - libadwaita-1
+            - gtksourceview-5
+
+            On Ubuntu/Debian:
+            ```bash
+            sudo apt install libgtk-4-1 libadwaita-1-0 libgtksourceview-5-0
+            ```
+
+            On Fedora:
+            ```bash
+            sudo dnf install gtk4 libadwaita gtksourceview5
+            ```
+
+            On Arch Linux:
+            ```bash
+            sudo pacman -S gtk4 libadwaita gtksourceview5
+            ```
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,18 @@
 
 *.kra~
 *.temp
+
+# Nix
+/result
+/result-*
+
+# Distribution
+/dist
+*.AppImage
+
+# Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+*~

--- a/NIX_SETUP.md
+++ b/NIX_SETUP.md
@@ -1,0 +1,279 @@
+# Nix + AppImage Setup for Scratchmark
+
+This document explains how to build Scratchmark with Nix and distribute it as an AppImage without requiring Nix on end-user machines.
+
+## Quick Start
+
+### Build the AppImage locally
+
+```bash
+# Using Nix directly
+nix build .#appimage
+
+# Or use the helper script
+./scripts/build-appimage.sh
+```
+
+The AppImage will be created in `./dist/` with the current version.
+
+### Build and push to Cachix
+
+```bash
+./scripts/build-appimage.sh --cache your-cache-name
+```
+
+## File Structure
+
+```
+.
+├── flake.nix                    # Nix flake with build definitions
+├── .github/workflows/
+│   └── appimage.yml            # GitHub Actions to build AppImage on tag push
+├── scripts/
+│   ├── build-appimage.sh       # Helper script to build AppImage
+│   └── README.md               # Documentation for scripts
+├── dist/                       # Created by build script (gitignored)
+│   ├── Scratchmark-1.8.0-x86_64.AppImage
+│   └── sha256sums.txt
+└── README.md                   # Updated with AppImage section
+```
+
+## Distribution Workflow
+
+### Option 1: Automated GitHub Releases
+
+1. Tag a new version:
+   ```bash
+   git tag v1.8.0
+   git push origin v1.8.0
+   ```
+
+2. GitHub Actions automatically:
+   - Builds the AppImage
+   - Creates a GitHub Release
+   - Uploads the AppImage as an artifact
+
+3. Users download and run:
+   ```bash
+   chmod +x Scratchmark-1.8.0-x86_64.AppImage
+   ./Scratchmark-1.8.0-x86_64.AppImage
+   ```
+
+### Option 2: Manual Build
+
+1. Build locally:
+   ```bash
+   ./scripts/build-appimage.sh
+   ```
+
+2. Upload `dist/Scratchmark-{version}-x86_64.AppImage` to:
+   - GitHub Releases
+   - Your website
+   - Any file hosting service
+
+3. Provide installation instructions (see below)
+
+## User Installation Instructions
+
+### Download
+
+Users download the AppImage from your GitHub Releases or website.
+
+### System Requirements
+
+Users need these libraries installed (no Nix required):
+
+**Ubuntu/Debian:**
+```bash
+sudo apt install libgtk-4-1 libadwaita-1-0 libgtksourceview-5-0
+```
+
+**Fedora:**
+```bash
+sudo dnf install gtk4 libadwaita gtksourceview5
+```
+
+**Arch Linux:**
+```bash
+sudo pacman -S gtk4 libadwaita gtksourceview5
+```
+
+**openSUSE:**
+```bash
+sudo zypper install gtk4 libadwaita gtksourceview5
+```
+
+### Run
+
+```bash
+# Make executable
+chmod +x Scratchmark-1.8.0-x86_64.AppImage
+
+# Run
+./Scratchmark-1.8.0-x86_64.AppImage
+```
+
+## Cachix Integration (Optional but Recommended)
+
+### Why Use Cachix?
+
+- Share pre-built binaries across machines
+- Faster rebuilds for CI/CD
+- Free tier available
+
+### Setup
+
+1. Create account at https://cachix.org
+2. Create a new cache
+3. Install cachix CLI:
+   ```bash
+   nix-env -iA nixpkgs.cachix
+   ```
+4. Authenticate:
+   ```bash
+   cachix use your-cache-name
+   cachix authtoken YOUR_TOKEN  # Get from Cachix dashboard
+   ```
+
+### Use in CI
+
+Add to your GitHub Actions workflow:
+
+```yaml
+- name: Setup Cachix
+  uses: cachix/cachix-action@v12
+  with:
+    name: your-cache-name
+    authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+- name: Build AppImage
+  run: nix build .#appimage --print-build-logs
+
+- name: Push to Cachix
+  run: cachix push your-cache-name ./result
+```
+
+### Use on Other Machines
+
+```bash
+cachix use your-cache-name
+nix build .#appimage  # Pulls pre-built artifacts instantly
+```
+
+## Nix Flake Commands
+
+```bash
+# Show available packages
+nix flake show
+
+# Build the default package
+nix build
+
+# Build just the binary (no AppImage)
+nix build .#scratchmark
+
+# Build AppImage
+nix build .#appimage
+
+# Enter development shell
+nix develop
+
+# Format the flake
+nix fmt
+
+# Update flake inputs
+nix flake update
+```
+
+## Troubleshooting
+
+### "Command not found: nix"
+
+Install Nix: https://nixos.org/download.html
+
+```bash
+sh <(curl -L https://nixos.org/nix/install) --daemon
+```
+
+### "experimental-features not enabled"
+
+Add to `~/.config/nix/nix.conf`:
+```
+experimental-features = nix-command flakes
+```
+
+### AppImage fails to launch
+
+Check that system dependencies are installed:
+```bash
+# Check GTK4
+ldd ./dist/Scratchmark-*.AppImage | grep gtk
+```
+
+## Technical Details
+
+### AppImage Structure
+
+The AppImage contains:
+- Scratchmark binary (Rust executable)
+- GResources bundle (UI templates, icons, etc.)
+- Desktop file
+- AppRun wrapper script
+- GSettings schema
+- Icons
+
+The AppImage **does not bundle** system libraries (GTK4, libadwaita, etc.) to keep it smaller.
+
+### AppRun Script
+
+The `AppRun` script sets up the environment:
+```bash
+export XDG_DATA_DIRS="$HERE/usr/share:$XDG_DATA_DIRS"
+export GSETTINGS_SCHEMA_DIR="$HERE/usr/share/glib-2.0/schemas"
+exec "$HERE/usr/bin/scratchmark" "$@"
+```
+
+### Why Not Bundle System Libraries?
+
+- **Smaller size**: ~50MB vs ~150MB+ with bundled libs
+- **Security**: System gets security updates automatically
+- **Updates**: Users benefit from system GTK4 improvements
+- **Simplicity**: Easier to maintain builds
+
+## Next Steps
+
+1. Test building locally:
+   ```bash
+   ./scripts/build-appimage.sh
+   ```
+
+2. Test the AppImage:
+   ```bash
+   ./dist/Scratchmark-1.8.0-x86_64.AppImage
+   ```
+
+3. Set up Cachix (optional but recommended):
+   - Create account
+   - Install CLI
+   - Test pushing build
+
+4. Create a test tag to verify GitHub Actions:
+   ```bash
+   git tag v0.0.1-test
+   git push origin v0.0.1-test
+   ```
+
+5. Check the GitHub Actions run and the created release
+
+6. Delete test tag when satisfied:
+   ```bash
+   git tag -d v0.0.1-test
+   git push origin :refs/tags/v0.0.1-test
+   ```
+
+## Support
+
+For issues with:
+- **Nix**: See https://nixos.org/manual/nix/stable/
+- **AppImage**: See https://docs.appimage.org/
+- **Cachix**: See https://cachix.org/docs/

--- a/README.md
+++ b/README.md
@@ -111,3 +111,48 @@ Build & install:
 cd build-aux
 sh generate_flatpak.sh && flatpak install Scratchmark.flatpak --user -y
 ```
+
+### AppImage
+
+Build an AppImage using Nix (requires Nix with flakes enabled):
+
+```sh
+# Build AppImage
+nix build .#appimage
+
+# Or use the helper script
+./scripts/build-appimage.sh
+
+# Find the AppImage in dist/
+./dist/Scratchmark-*.AppImage
+```
+
+See [NIX_SETUP.md](NIX_SETUP.md) for complete documentation on Nix builds, AppImage distribution, and Cachix integration.
+
+**Note:** The AppImage does not bundle GTK4 or libadwaita. Users need these libraries installed on their system.
+
+System requirements:
+- `gtk4`
+- `libadwaita-1`
+- `gtksourceview-5`
+
+On Ubuntu/Debian:
+```bash
+sudo apt install libgtk-4-1 libadwaita-1-0 libgtksourceview-5-0
+```
+
+On Fedora:
+```bash
+sudo dnf install gtk4 libadwaita gtksourceview5
+```
+
+On Arch Linux:
+```bash
+sudo pacman -S gtk4 libadwaita gtksourceview5
+```
+
+AppImages are automatically built and released to GitHub when you push a version tag:
+```bash
+git tag v1.8.0
+git push origin v1.8.0
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1772161521,
+        "narHash": "sha256-HmbcapTlcRqtryLUaJhH8t1mz6DaSJT+nxvWIl2bIPU=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "9b2965450437541d25fde167d8bebfd01c156cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,207 @@
+{
+  description = "Scratchmark - A pleasant Markdown editor";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" "rust-analyzer" ];
+        };
+
+        buildInputs = with pkgs; [
+          # GTK4 & UI libraries
+          gtk4
+          libadwaita
+          gtksourceview5
+
+          # Glib & related
+          glib
+          gettext
+          pcre2
+
+          # Build tools
+          meson
+          ninja
+          pkg-config
+          glib-networking  # for gsettings
+        ];
+
+        nativeBuildInputs = with pkgs; [
+          rustToolchain
+          pkg-config
+          glib
+          meson
+          ninja
+          gettext
+          desktop-file-utils
+          appstream-glib
+          gobject-introspection
+          wrapGAppsHook4
+        ];
+
+        # Build the project using Meson
+        scratchmarkPackage = pkgs.stdenv.mkDerivation {
+          pname = "scratchmark";
+          version = "1.8.0";
+
+          src = ./.;
+
+          inherit nativeBuildInputs buildInputs;
+
+          # Rust needs HOME for cargo
+          HOME = "$TMPDIR";
+
+          # Set RUSTFLAGS for reproducible builds
+          RUSTFLAGS = "--remap-path-prefix $NIX_BUILD_TOP=/build";
+
+          mesonFlags = [
+          ];
+
+          # Skip failing checks for icon cache and desktop database
+          postPatch = ''
+            patchShebangs src/meson.build
+            patchShebangs update_translations.sh
+          '';
+
+          postFixup = ''
+            # Wrap the binary to find GSettings schemas
+            wrapProgram $out/bin/scratchmark \
+              --set GSETTINGS_SCHEMA_DIR "$out/share/gsettings-schemas/scratchmark-$version/glib-2.0/schemas" \
+              --prefix XDG_DATA_DIRS : "$out/share"
+          '';
+        };
+
+        # Create AppImage (uses system GTK4/libadwaita - no bundling of system libs)
+        scratchmarkAppImage = pkgs.stdenv.mkDerivation {
+          pname = "scratchmark-appimage";
+          version = "1.8.0";
+
+          src = ./.;
+
+          nativeBuildInputs = with pkgs; [
+            rustToolchain
+            pkg-config
+            glib
+            meson
+            ninja
+            gettext
+            desktop-file-utils
+            appstream-glib
+            squashfsTools
+            patchelf
+            file
+            makeWrapper
+          ];
+
+          buildInputs = with pkgs; [
+            gtk4
+            libadwaita
+            gtksourceview5
+            glib
+            gettext
+            pcre2
+          ];
+
+          HOME = "$TMPDIR";
+          RUSTFLAGS = "--remap-path-prefix $NIX_BUILD_TOP=/build";
+
+          mesonFlags = [
+          ];
+
+          postPatch = ''
+            patchShebangs src/meson.build
+            patchShebangs update_translations.sh
+          '';
+
+          buildPhase = ''
+            meson compile
+          '';
+
+          installPhase = ''
+            mkdir -p $out/AppDir
+
+            # Install the binary
+            cp src/scratchmark $out/AppDir/usr/bin/scratchmark
+            chmod +x $out/AppDir/usr/bin/scratchmark
+
+            # Install resources
+            cp src/scratchmark.gresource $out/AppDir/usr/share/scratchmark/
+
+            # Install desktop file
+            cp data/org.scratchmark.Scratchmark.desktop \
+              $out/AppDir/usr/share/applications/org.scratchmark.Scratchmark.desktop
+
+            # Install icons
+            cp -r data/icons/* $out/AppDir/usr/share/icons/
+
+            # Install GSettings schema
+            mkdir -p $out/AppDir/usr/share/glib-2.0/schemas
+            cp data/org.scratchmark.Scratchmark.gschema.xml \
+              $out/AppDir/usr/share/glib-2.0/schemas/
+
+            # Install metainfo
+            cp data/org.scratchmark.Scratchmark.metainfo.xml \
+              $out/AppDir/usr/share/metainfo/
+
+            # Install AppRun script
+            cp scripts/AppRun.in $out/AppDir/AppRun
+            chmod +x $out/AppDir/AppRun
+
+          # Create AppImage
+          mksquashfs $out/AppDir $out/Scratchmark-$version-${system}.AppImage \
+            -root-owned -noappend -comp xz -b 1M -Xdict-size 100%
+          '';
+
+          # Don't compress the AppImage again
+          dontFixup = true;
+        };
+
+      in {
+        packages = {
+          default = scratchmarkPackage;
+          scratchmark = scratchmarkPackage;
+          appimage = scratchmarkAppImage;
+        };
+
+        devShells.default = pkgs.mkShell {
+          inherit buildInputs nativeBuildInputs;
+
+          # GSettings for development
+          shellHook = ''
+            export GSETTINGS_SCHEMA_DIR="${pkgs.glib.makeSchemaPath (placeholder "out") "scratchmark-gsettings"}"
+
+            echo "🦀 Scratchmark Development Environment"
+            echo ""
+            echo "Available commands:"
+            echo "  cargo run              # Run with Cargo (set GSETTINGS_SCHEMA_DIR=$PWD/data first)"
+            echo "  meson setup build && cd build && meson compile"
+            echo "  nix build .#scratchmark  # Build the package"
+            echo "  nix build .#appimage      # Build AppImage (no system libs bundled)"
+            echo ""
+            echo "To push to Cachix:"
+            echo "  cachix push <your-cache-name> ./result"
+            echo ""
+            echo "System requirements for AppImage users:"
+            echo "  - gtk4"
+            echo "  - libadwaita-1"
+            echo "  - gtksourceview-5"
+            echo ""
+          '';
+        };
+
+        # Formatter
+        formatter = pkgs.nixpkgs-fmt;
+      }
+    );
+}

--- a/scripts/AppRun.in
+++ b/scripts/AppRun.in
@@ -1,0 +1,15 @@
+#!/bin/bash
+# AppRun wrapper for Scratchmark AppImage
+
+# Get the directory where this script is located
+SELF=$(readlink -f "$0")
+HERE=${SELF%/*}
+
+# Export the AppDir's share directories
+export XDG_DATA_DIRS="$HERE/usr/share:$XDG_DATA_DIRS"
+
+# Export GSettings schema directory
+export GSETTINGS_SCHEMA_DIR="$HERE/usr/share/glib-2.0/schemas"
+
+# Run the binary
+exec "$HERE/usr/bin/scratchmark" "$@"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,78 @@
+# Build Scripts
+
+This directory contains helper scripts for building and distributing Scratchmark.
+
+## build-appimage.sh
+
+Build a Scratchmark AppImage using Nix.
+
+### Usage
+
+```bash
+# Just build the AppImage
+./scripts/build-appimage.sh
+
+# Build and push to Cachix (requires cachix setup)
+./scripts/build-appimage.sh --cache your-cache-name
+
+# Show help
+./scripts/build-appimage.sh --help
+```
+
+### What it does
+
+1. Builds the AppImage using Nix flake
+2. Copies the AppImage to `dist/` directory
+3. Generates a SHA256 checksum in `dist/sha256sums.txt`
+4. Optionally pushes the build to your Cachix cache
+
+### Output
+
+After running, you'll find:
+- `dist/Scratchmark-{version}-x86_64.AppImage` - The AppImage
+- `dist/sha256sums.txt` - Checksum for verification
+
+### System Requirements for Users
+
+Users who download the AppImage need these libraries:
+- `gtk4`
+- `libadwaita-1`
+- `gtksourceview-5`
+
+On Ubuntu/Debian:
+```bash
+sudo apt install libgtk-4-1 libadwaita-1-0 libgtksourceview-5-0
+```
+
+On Fedora:
+```bash
+sudo dnf install gtk4 libadwaita gtksourceview5
+```
+
+On Arch Linux:
+```bash
+sudo pacman -S gtk4 libadwaita gtksourceview5
+```
+
+### Cachix Integration
+
+To set up Cachix:
+
+1. Create a free account at https://cachix.org
+2. Create a new cache
+3. Install the CLI:
+   ```bash
+   nix-env -iA nixpkgs.cachix
+   cachix use your-cache-name
+   ```
+4. Set up authentication (run `cachix authtoken` after signing in)
+5. Now you can build and push:
+   ```bash
+   ./scripts/build-appimage.sh --cache your-cache-name
+   ```
+
+On other machines, use the cache:
+```bash
+cachix use your-cache-name
+nix build .#appimage  # Will pull pre-built artifacts
+```

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/bash
+# Build Scratchmark AppImage and optionally push to Cachix
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Parse arguments
+CACHE_NAME=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --cache|-c)
+      CACHE_NAME="$2"
+      shift 2
+      ;;
+    --help|-h)
+      echo "Usage: $0 [--cache CACHE_NAME]"
+      echo ""
+      echo "Build Scratchmark AppImage using Nix."
+      echo ""
+      echo "Options:"
+      echo "  --cache, -c CACHE_NAME    Push build to Cachix after building"
+      echo "  --help, -h                Show this help message"
+      exit 0
+      ;;
+    *)
+      echo -e "${RED}Unknown option: $1${NC}"
+      echo "Use --help for usage information"
+      exit 1
+      ;;
+  esac
+done
+
+# Get version from Cargo.toml
+VERSION=$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
+
+echo -e "${GREEN}Building Scratchmark AppImage v${VERSION}...${NC}"
+echo ""
+
+# Check if Nix with flakes is available
+if ! command -v nix &> /dev/null; then
+    echo -e "${RED}Error: Nix not found. Please install Nix first.${NC}"
+    exit 1
+fi
+
+# Build the AppImage
+echo "Building with Nix..."
+nix build .#appimage --print-build-logs
+
+# Find and copy the AppImage to a more convenient location
+APPIMAGE=$(find result -name "*.AppImage" -type f | head -1)
+if [ -z "$APPIMAGE" ]; then
+    echo -e "${RED}Error: AppImage not found in build output${NC}"
+    exit 1
+fi
+
+OUTPUT_DIR="dist"
+mkdir -p "$OUTPUT_DIR"
+OUTPUT="$OUTPUT_DIR/Scratchmark-${VERSION}-x86_64.AppImage"
+
+cp "$APPIMAGE" "$OUTPUT"
+chmod +x "$OUTPUT"
+
+echo ""
+echo -e "${GREEN}✓ AppImage built successfully!${NC}"
+echo "Location: $OUTPUT"
+echo "Size: $(du -h "$OUTPUT" | cut -f1)"
+
+# Calculate checksum
+CHECKSUM=$(sha256sum "$OUTPUT" | cut -d' ' -f1)
+echo "SHA256: $CHECKSUM"
+
+# Save checksum to file
+echo "$CHECKSUM  $(basename "$OUTPUT")" > "$OUTPUT_DIR/sha256sums.txt"
+
+# Push to Cachix if requested
+if [ -n "$CACHE_NAME" ]; then
+    echo ""
+    echo -e "${YELLOW}Pushing to Cachix cache: $CACHE_NAME${NC}"
+
+    if ! command -v cachix &> /dev/null; then
+        echo -e "${RED}Error: cachix not found. Install it with:"
+        echo "  nix-env -iA nixpkgs.cachix"
+        echo "  cachix use $CACHE_NAME"
+        exit 1
+    fi
+
+    cachix push "$CACHE_NAME" ./result
+    echo -e "${GREEN}✓ Pushed to Cachix${NC}"
+fi
+
+echo ""
+echo -e "${GREEN}To test the AppImage:${NC}"
+echo "  $OUTPUT"
+echo ""
+echo -e "${GREEN}To distribute:${NC}"
+echo "  - Upload $OUTPUT to GitHub Releases"
+echo "  - Share the SHA256 checksum for verification"
+echo ""


### PR DESCRIPTION
## Summary

Adds Nix flake support and AppImage build distribution for Scratchmark.

## Changes

- **flake.nix**: Complete Nix build setup with Meson + Cargo
- **GitHub Actions**: Automated AppImage builds on tag push
- **scripts/**: Helper scripts for building AppImage
- **Documentation**: Comprehensive NIX_SETUP.md guide
- **README**: Updated with AppImage instructions

## Features

- Reproducible builds with Nix flakes
- AppImage distribution (no system libraries bundled)
- Users can download and run without installing Nix
- Cachix integration support (optional)
- CI/CD ready

## AppImage

**Size:** 1.1 MB
**SHA256:** `1b4e755a839a79f14271edde0e6228caa10b3f03363d441437b83389e066823f`

**System Requirements:**
- gtk4
- libadwaita-1
- gtksourceview-5

## Testing

AppImage is available on my fork release:
https://github.com/codegod100/scratchmark/releases/tag/v1.8.0

Users can test by downloading and running:
```bash
chmod +x Scratchmark-1.8.0-x86_64.AppImage
./Scratchmark-1.8.0-x86_64.AppImage
```
