### PR TITLE
Allow sorting by time accessed

### DIFF
--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -214,6 +214,16 @@
         <attribute name="action">library.sort-type</attribute>
         <attribute name="target">ModifiedAsc</attribute>
       </item>
+      <item>
+        <attribute name="label" translatable="yes">Last Accessed</attribute>
+        <attribute name="action">library.sort-type</attribute>
+        <attribute name="target">AccessedDesc</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">First Accessed</attribute>
+        <attribute name="action">library.sort-type</attribute>
+        <attribute name="target">AccessedAsc</attribute>
+      </item>
     </section>
   </menu>
 </interface>

--- a/src/data/document.rs
+++ b/src/data/document.rs
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn test_move_valid_path() {
         std::fs::create_dir_all(PathBuf::from(PROJECT_ROOT).join("test")).unwrap();
-        let doc = Document::new("path/to/".into(), 1, SystemTime::now());
+        let doc = Document::new("path/to/".into(), 1, SystemTime::now(), SystemTime::now());
         assert!(
             doc.rename(PathBuf::from(PROJECT_ROOT).join("test").join("new_file.md"))
                 .is_ok()
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn test_move_invalid_path_noparent() {
-        let doc = Document::new("path/to/".into(), 1, SystemTime::now());
+        let doc = Document::new("path/to/".into(), 1, SystemTime::now(), SystemTime::now());
         doc.connect_closure(
             "rename-requested",
             false,

--- a/src/data/document.rs
+++ b/src/data/document.rs
@@ -28,6 +28,7 @@ mod imp {
         #[property(get, set)]
         pub(super) is_open_in_editor: Cell<bool>,
         pub(super) modified: RefCell<Option<SystemTime>>,
+        pub(super) accessed: RefCell<Option<SystemTime>>,
         pub(super) collation_key: OnceLock<CollationKey>,
     }
 
@@ -82,11 +83,15 @@ impl Document {
         self.imp().modified.borrow().unwrap()
     }
 
+    pub fn accessed(&self) -> SystemTime {
+        self.imp().accessed.borrow().unwrap()
+    }
+
     pub fn collation_key(&self) -> &CollationKey {
         self.imp().collation_key.get().unwrap()
     }
 
-    pub fn new(path: PathBuf, depth: u32, modified: SystemTime) -> Self {
+    pub fn new(path: PathBuf, depth: u32, modified: SystemTime, accessed: SystemTime) -> Self {
         let stem = path.file_stem().unwrap().to_string_lossy().into_owned();
         let name = path.file_name().unwrap().to_string_lossy().into_owned();
         let collation_key = CollationKey::from(&name);
@@ -100,6 +105,7 @@ impl Document {
 
         let imp = obj.imp();
         imp.modified.replace(Some(modified));
+        imp.accessed.replace(Some(accessed));
         imp.collation_key.set(collation_key).unwrap();
 
         obj
@@ -111,6 +117,7 @@ impl Document {
 
     pub fn open(&self) {
         self.emit_by_name::<()>("open", &[]);
+        self.set_accessed(SystemTime::now());
     }
 
     pub fn duplicate(&self) {
@@ -144,6 +151,11 @@ impl Document {
 
     pub fn set_modified(&self, modified: SystemTime) {
         self.imp().modified.borrow_mut().replace(modified);
+        self.emit_by_name::<()>("metadata-changed", &[]);
+    }
+
+    pub fn set_accessed(&self, accessed: SystemTime) {
+        self.imp().accessed.borrow_mut().replace(accessed);
         self.emit_by_name::<()>("metadata-changed", &[]);
     }
 }

--- a/src/data/folder.rs
+++ b/src/data/folder.rs
@@ -33,6 +33,7 @@ mod imp {
 
         pub(super) kind: OnceLock<FolderType>,
         pub(super) modified: RefCell<Option<SystemTime>>,
+        pub(super) accessed: RefCell<Option<SystemTime>>,
         pub(super) collation_key: OnceLock<CollationKey>,
     }
 
@@ -106,11 +107,20 @@ impl Folder {
         self.imp().modified.borrow().unwrap()
     }
 
+    pub fn accessed(&self) -> SystemTime {
+        self.imp().accessed.borrow().unwrap()
+    }
+
     pub fn collation_key(&self) -> &CollationKey {
         self.imp().collation_key.get().unwrap()
     }
 
-    pub fn new_subfolder(path: PathBuf, depth: u32, modified: SystemTime) -> Self {
+    pub fn new_subfolder(
+        path: PathBuf,
+        depth: u32,
+        modified: SystemTime,
+        accessed: SystemTime,
+    ) -> Self {
         let name = path.file_name().unwrap().to_string_lossy().into_owned();
         let collation_key = CollationKey::from(&name);
 
@@ -123,6 +133,7 @@ impl Folder {
         let imp = obj.imp();
         imp.kind.set(FolderType::Subfolder).unwrap();
         imp.modified.replace(Some(modified));
+        imp.accessed.replace(Some(accessed));
         imp.collation_key.set(collation_key).unwrap();
 
         obj
@@ -141,6 +152,7 @@ impl Folder {
         let imp = obj.imp();
         imp.kind.set(FolderType::ProjectRoot).unwrap();
         imp.modified.replace(Some(SystemTime::now()));
+        imp.accessed.replace(Some(SystemTime::now()));
         imp.collation_key.set(collation_key).unwrap();
 
         obj
@@ -160,6 +172,7 @@ impl Folder {
         let imp = obj.imp();
         imp.kind.set(FolderType::DraftsRoot).unwrap();
         imp.modified.replace(Some(SystemTime::now()));
+        imp.accessed.replace(Some(SystemTime::now()));
         imp.collation_key.set(collation_key).unwrap();
 
         obj
@@ -186,6 +199,7 @@ impl Folder {
 
     pub fn select(&self) {
         self.emit_by_name::<()>("selected", &[]);
+        self.set_accessed(SystemTime::now());
     }
 
     pub fn add_document(&self, doc: Document) {
@@ -298,6 +312,10 @@ impl Folder {
             self.emit_by_name::<()>("metadata-changed", &[]);
         }
     }
+
+    pub fn set_accessed(&self, accessed: SystemTime) {
+        self.imp().accessed.borrow_mut().replace(accessed);
+    }
 }
 
 #[cfg(test)]
@@ -312,7 +330,8 @@ mod tests {
     #[test]
     fn test_move_valid_path() {
         std::fs::create_dir_all(PathBuf::from(PROJECT_ROOT).join("test")).unwrap();
-        let folder = Folder::new_subfolder("path/to/".into(), 1, SystemTime::now());
+        let folder =
+            Folder::new_subfolder("path/to/".into(), 1, SystemTime::now(), SystemTime::now());
         assert!(
             folder
                 .rename(PathBuf::from(PROJECT_ROOT).join("test").join("new_folder"))
@@ -322,7 +341,8 @@ mod tests {
 
     #[test]
     fn test_move_invalid_path_noparent() {
-        let folder = Folder::new_subfolder("path/to/".into(), 1, SystemTime::now());
+        let folder =
+            Folder::new_subfolder("path/to/".into(), 1, SystemTime::now(), SystemTime::now());
         folder.connect_closure(
             "rename-requested",
             false,

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -44,6 +44,13 @@ impl ProjectItem {
         }
     }
 
+    pub fn accessed(&self) -> SystemTime {
+        match self {
+            ProjectItem::Doc(doc) => doc.accessed(),
+            ProjectItem::Dir(dir) => dir.accessed(),
+        }
+    }
+
     pub fn collation_key(&self) -> &CollationKey {
         match self {
             ProjectItem::Doc(doc) => doc.collation_key(),

--- a/src/data/project.rs
+++ b/src/data/project.rs
@@ -30,11 +30,13 @@ mod imp {
             path: PathBuf,
             depth: u32,
             modified: SystemTime,
+            accessed: SystemTime,
         },
         FoundFile {
             path: PathBuf,
             depth: u32,
             modified: SystemTime,
+            accessed: SystemTime,
         },
         Done,
     }
@@ -84,17 +86,21 @@ mod imp {
                                         path,
                                         depth,
                                         modified,
+                                        accessed,
                                     } => {
                                         imp.add_folder(Folder::new_subfolder(
-                                            path, depth, modified,
+                                            path, depth, modified, accessed,
                                         ));
                                     }
                                     CrawlMsg::FoundFile {
                                         path,
                                         depth,
                                         modified,
+                                        accessed,
                                     } => {
-                                        imp.add_document(Document::new(path, depth, modified));
+                                        imp.add_document(Document::new(
+                                            path, depth, modified, accessed,
+                                        ));
                                     }
                                     CrawlMsg::Done => {
                                         imp.prune();
@@ -184,6 +190,7 @@ mod imp {
                         }
                         let path = entry.path();
                         let modified = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+                        let accessed = metadata.accessed().unwrap_or(SystemTime::UNIX_EPOCH);
 
                         if metadata.is_dir() {
                             search_stack.push_back((path.clone(), depth + 1));
@@ -191,6 +198,7 @@ mod imp {
                                 path,
                                 depth,
                                 modified,
+                                accessed,
                             });
                         } else {
                             if !path
@@ -204,6 +212,7 @@ mod imp {
                                 path,
                                 depth,
                                 modified,
+                                accessed,
                             });
                         }
                     }

--- a/src/data/sort.rs
+++ b/src/data/sort.rs
@@ -112,6 +112,18 @@ mod imp {
                     }
                     not_equal => not_equal.into(),
                 },
+                SortMethod::AccessedAsc => match item_a.accessed().cmp(&item_b.accessed()) {
+                    std::cmp::Ordering::Equal => {
+                        item_a.collation_key().cmp(item_b.collation_key()).into()
+                    }
+                    not_equal => not_equal.into(),
+                },
+                SortMethod::AccessedDesc => match item_b.accessed().cmp(&item_a.accessed()) {
+                    std::cmp::Ordering::Equal => {
+                        item_a.collation_key().cmp(item_b.collation_key()).into()
+                    }
+                    not_equal => not_equal.into(),
+                },
             }
         }
     }
@@ -134,6 +146,8 @@ pub enum SortMethod {
     AlphanumericDesc,
     ModifiedAsc,
     ModifiedDesc,
+    AccessedAsc,
+    AccessedDesc,
 }
 
 impl Display for SortMethod {
@@ -143,6 +157,8 @@ impl Display for SortMethod {
             SortMethod::AlphanumericDesc => write!(f, "AlphanumericDesc"),
             SortMethod::ModifiedAsc => write!(f, "ModifiedAsc"),
             SortMethod::ModifiedDesc => write!(f, "ModifiedDesc"),
+            SortMethod::AccessedAsc => write!(f, "AccessedAsc"),
+            SortMethod::AccessedDesc => write!(f, "AccessedDesc"),
         }
     }
 }
@@ -156,6 +172,8 @@ impl TryFrom<&str> for SortMethod {
             "AlphanumericDesc" => Ok(Self::AlphanumericDesc),
             "ModifiedAsc" => Ok(Self::ModifiedAsc),
             "ModifiedDesc" => Ok(Self::ModifiedDesc),
+            "AccessedAsc" => Ok(Self::AccessedAsc),
+            "AccessedDesc" => Ok(Self::AccessedDesc),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
This adds a way to sort files by the most recent time they were open. Similar to modified, but this is useful for when a file was opened recently but was not changed.