### PR TITLE
Add option to insert tabs as spaces

### DIFF
--- a/data/org.scratchmark.Scratchmark.gschema.xml
+++ b/data/org.scratchmark.Scratchmark.gschema.xml
@@ -34,6 +34,9 @@
     <key name="editor-show-minimap" type="b">
       <default>false</default>
     </key>
+    <key name="editor-tabs-as-spaces" type="b">
+      <default>false</default>
+    </key>
     <key name="editor-font-family" type="s">
       <default>"Monospace"</default>
     </key>

--- a/data/resources/ui/preferences_dialog.ui
+++ b/data/resources/ui/preferences_dialog.ui
@@ -33,6 +33,12 @@
               </object>
             </child>
             <child>
+              <object class="AdwSwitchRow" id="editor_tabs_as_spaces_toggle">
+                <property name="title" translatable="yes">Insert Tabs As Spaces</property>
+                <property name="subtitle" translatable="yes">Pressing the tab key will insert 4 spaces</property>
+              </object>
+            </child>
+            <child>
               <object class="AdwSwitchRow" id="editor_limit_width_toggle">
                 <property name="title" translatable="yes">Clamp Editor Width</property>
               </object>

--- a/src/widgets/editor/mod.rs
+++ b/src/widgets/editor/mod.rs
@@ -37,6 +37,7 @@ mod imp {
     use gtk::glib::subclass::Signal;
     use libspelling::Checker;
     use libspelling::TextBufferAdapter;
+    use sourceview5::prelude::ViewExt;
 
     use super::document_stats_view::DocumentStatsView;
     use super::minimap::Minimap;
@@ -59,6 +60,8 @@ mod imp {
         show_sidebar: Cell<bool>,
         #[property(get, set)]
         font_size: Cell<u32>,
+        #[property(get, set)]
+        tabs_as_spaces: Cell<bool>,
         #[property(get, set)]
         font_family: RefCell<GString>,
         #[property(get, set)]
@@ -211,6 +214,10 @@ mod imp {
 
             obj.connect_font_family_notify(clone!(move |obj| {
                 obj.imp().refresh_font();
+            }));
+
+            obj.connect_tabs_as_spaces_notify(clone!(move |obj| {
+                obj.imp().refresh_tabs_as_spaces()
             }));
 
             obj.connect_font_size_notify(clone!(move |obj| {
@@ -408,6 +415,12 @@ mod imp {
             let obj = self.obj();
             self.source_view
                 .set_font(&obj.font_family(), obj.font_size());
+        }
+
+        fn refresh_tabs_as_spaces(&self) {
+            let obj = self.obj();
+            self.source_view
+                .set_insert_spaces_instead_of_tabs(obj.tabs_as_spaces());
         }
 
         fn refresh_max_width(&self) {

--- a/src/widgets/preferences_dialog.rs
+++ b/src/widgets/preferences_dialog.rs
@@ -25,6 +25,8 @@ mod imp {
         #[template_child]
         editor_minimap_toggle: TemplateChild<SwitchRow>,
         #[template_child]
+        editor_tabs_as_spaces_toggle: TemplateChild<SwitchRow>,
+        #[template_child]
         editor_limit_width_toggle: TemplateChild<SwitchRow>,
         #[template_child]
         editor_max_width_spin: TemplateChild<SpinRow>,
@@ -76,6 +78,14 @@ mod imp {
             let editor_minimap_toggle: &SwitchRow = &self.editor_minimap_toggle;
             settings
                 .bind("editor-show-minimap", editor_minimap_toggle, "active")
+                .build();
+            let editor_tabs_as_spaces_toggle: &SwitchRow = &self.editor_tabs_as_spaces_toggle;
+            settings
+                .bind(
+                    "editor-tabs-as-spaces",
+                    editor_tabs_as_spaces_toggle,
+                    "active",
+                )
                 .build();
             let editor_limit_width_toggle: &SwitchRow = &self.editor_limit_width_toggle;
             settings

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -1077,6 +1077,9 @@ mod imp {
                 .bind("editor-show-minimap", &editor, "show-minimap")
                 .build();
             settings
+                .bind("editor-tabs-as-spaces", &editor, "tabs-as-spaces")
+                .build();
+            settings
                 .bind("editor-use-spellcheck", &editor, "use_spellcheck")
                 .build();
 


### PR DESCRIPTION
Adds option in the preferences menu. If selected then typing tab inserts spaces not tab.

Closes #128